### PR TITLE
Get redis connection properly

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -161,7 +161,7 @@ class ClusterPoller(MultiChannelPoller):
                     if node:
                         break
                 except Exception as e:
-                    logger.warning('Error while getting node from key', extra={"e": e, "key": conn.key})
+                    logger.error('Error while getting node from key', extra={"e": e, "key": conn.key})
 
                 sleep(backoff[tries])
                 channel.client.nodes_manager.initialize()
@@ -197,7 +197,7 @@ class ClusterPoller(MultiChannelPoller):
                 try:
                     self._register(*ident)
                 except Exception as e:
-                    logger.warning('Error while registering BRPOP', extra={"e": e, "key": conn.key})
+                    logger.error('Error while registering BRPOP', extra={"e": e, "key": conn.key})
 
         channel._brpop_start()
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -149,10 +149,12 @@ class ClusterPoller(MultiChannelPoller):
         if not conn.client:
             if conn.key in channel.ask_errors:
                 ask_error = channel.ask_errors[conn.key]
-                node = channel.client.nodes_manager.get_node(ask_error.host, ask_error.port)
+                node = channel.client.get_node(ask_error.host, ask_error.port)
             else:
-                node = channel.client.nodes_manager.get_node_from_slot(channel.client.keyslot(conn.key))
-            conn.client = node.redis_connection.client()
+                node = channel.client.get_node_from_key(conn.key)
+
+            redis_connection = channel.client.get_redis_connection(node)
+            conn.client = redis_connection.client()
 
         sock = conn.client.connection._sock
         self._fd_to_chan[sock.fileno()] = (channel, conn, cmd)

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -147,11 +147,20 @@ class ClusterPoller(MultiChannelPoller):
             self._unregister(*ident)
 
         if not conn.client:
-            if conn.key in channel.ask_errors:
-                ask_error = channel.ask_errors[conn.key]
-                node = channel.client.get_node(ask_error.host, ask_error.port)
-            else:
-                node = channel.client.get_node_from_key(conn.key)
+            tries = 0
+            while True:
+                if tries > 3:
+                    raise ValueError('Cannot find node for key: {}'.format(conn.key))
+                if conn.key in channel.ask_errors:
+                    ask_error = channel.ask_errors[conn.key]
+                    node = channel.client.get_node(ask_error.host, ask_error.port)
+                else:
+                    node = channel.client.get_node_from_key(conn.key)
+                if node:
+                    break
+
+                channel.client.nodes_manager.initialize()
+                tries += 1
 
             redis_connection = channel.client.get_redis_connection(node)
             conn.client = redis_connection.client()
@@ -180,7 +189,10 @@ class ClusterPoller(MultiChannelPoller):
             ident = (channel, channel.client, conn, 'BRPOP')
 
             if (ident not in self._chan_to_sock):
-                self._register(*ident)
+                try:
+                    self._register(*ident)
+                except Exception as e:
+                    logger.warning('Error while registering BRPOP', extra={"e": e, "key": conn.key})
 
         channel._brpop_start()
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from time import time
+from time import time, sleep
 from queue import Empty
 from collections import defaultdict
 
@@ -148,6 +148,7 @@ class ClusterPoller(MultiChannelPoller):
 
         if not conn.client:
             tries = 0
+            backoff = [0, 0.1, 0.2, 0.4]
             while True:
                 if tries > 3:
                     raise ValueError('Cannot find node for key: {}'.format(conn.key))
@@ -159,6 +160,7 @@ class ClusterPoller(MultiChannelPoller):
                 if node:
                     break
 
+                sleep(backoff[tries])
                 channel.client.nodes_manager.initialize()
                 tries += 1
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -152,13 +152,16 @@ class ClusterPoller(MultiChannelPoller):
             while True:
                 if tries > 3:
                     raise ValueError('Cannot find node for key: {}'.format(conn.key))
-                if conn.key in channel.ask_errors:
-                    ask_error = channel.ask_errors[conn.key]
-                    node = channel.client.get_node(ask_error.host, ask_error.port)
-                else:
-                    node = channel.client.get_node_from_key(conn.key)
-                if node:
-                    break
+                try:
+                    if conn.key in channel.ask_errors:
+                        ask_error = channel.ask_errors[conn.key]
+                        node = channel.client.get_node(ask_error.host, ask_error.port)
+                    else:
+                        node = channel.client.get_node_from_key(conn.key)
+                    if node:
+                        break
+                except Exception as e:
+                    logger.warning('Error while getting node from key', extra={"e": e, "key": conn.key})
 
                 sleep(backoff[tries])
                 channel.client.nodes_manager.initialize()


### PR DESCRIPTION
Current code doesn't create newly populated node's redis connection, getting error on redis cluster scaleout
```
  File "kombu/transport/redis_cluster.py", line 155, in _register
    conn.client = node.redis_connection.client()
AttributeError: 'NoneType' object has no attribute 'client
```
This PR Fixes two things:

1. https://github.com/sendbird/kombu/pull/9/commits/686fb4225d4699522b97d7e8a9b6e815aee32305 Properly get redis connection by using `RedisCluster.get_redis_connection`, and change some code to call `RedisCluster` methods instead of calling methods on `NodesManager
2. https://github.com/sendbird/kombu/pull/9/commits/7eab212f921c5ad6446cff160825d4c8d7cd1fe9 Handle node not found error