### PR TITLE
Use single queue per node on redis-cluster

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -364,6 +364,7 @@ class Channel(RedisChannel):
 
         self.ask_errors = {}
         self.physical_queues = {}
+        self.physical_queues_updated_at = None
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
@@ -396,6 +397,10 @@ class Channel(RedisChannel):
         self.physical_queues = {}  # Will be recomputed later
 
     def get_physical_queues(self, queues):
+        if self.physical_queues_updated_at and time() - self.physical_queues_updated_at > 60000:
+            self.physical_queues = {}  # update physical queue configuration every minute
+            self.physical_queues_updated_at = time()
+
         result = {k: v for k, v in self.physical_queues.items() if k in queues}
 
         remaining_queues = [x for x in queues if x not in result]

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -403,7 +403,11 @@ class Channel(RedisChannel):
             new_physical_queues = self.compute_physical_queue_names(remaining_queues)
             for queue in remaining_queues:
                 # Load queue names from redis to ensure listening physical queues before last redis slot configuration change.
-                cached_physical_queues = self.client.hgetall(self.physical_queue_cache_key.format(queue=queue))
+                try:
+                    cached_physical_queues = self.client.hgetall(self.physical_queue_cache_key.format(queue=queue))
+                except:
+                    logger.exception('Failed to get cache', extra={'queue': queue})
+                    cached_physical_queues = {}
 
                 # Merge cached and computed queue
                 # if cached_queue_names is not in new_physical_queues and has no expire, we should set its expiry
@@ -425,7 +429,10 @@ class Channel(RedisChannel):
                 # And update cache..
                 for queue_name, timeout in merged_physical_queues.items():
                     value = 0 if timeout is None else timeout
-                    self.client.hset(self.physical_queue_cache_key.format(queue=queue), queue_name, value)
+                    try:
+                        self.client.hset(self.physical_queue_cache_key.format(queue=queue), queue_name, value)
+                    except:
+                        logger.exception('Failed to set cache', extra={'queue': queue, 'queue_name': queue_name, 'value': value})
 
         return result
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -406,16 +406,14 @@ class Channel(RedisChannel):
                 cached_physical_queues = self.client.hgetall(self.physical_queue_cache_key.format(queue=queue))
 
                 # Merge cached and computed queue
-                # if newly computed queue is not in cached_queue_names and has no expire, we should set its expiry
-                merged_physical_queues = {}
+                # if cached_queue_names is not in new_physical_queues and has no expire, we should set its expiry
+                merged_physical_queues: Dict[str, Optional[int]] = {x: None for x in new_physical_queues[queue]}
 
-                for queue_name in new_physical_queues[queue]:
-                    merged_physical_queues[queue_name] = None
-                    if queue_name not in cached_physical_queues:
-                        merged_physical_queues[queue_name] = time() + self.physical_queue_timeout
                 for queue_name, timeout in cached_physical_queues.items():
                     queue_name = queue_name.decode('utf-8')
                     if queue_name not in merged_physical_queues:
+                        if timeout == 0:
+                            timeout = int(time() + self.physical_queue_timeout)
                         merged_physical_queues[queue_name] = timeout
 
                 physical_queue = PhysicalQueue(merged_physical_queues)
@@ -425,7 +423,8 @@ class Channel(RedisChannel):
 
                 # And update cache..
                 for queue_name, timeout in merged_physical_queues.items():
-                    self.client.hset(self.physical_queue_cache_key.format(queue=queue), queue_name, timeout)
+                    value = 0 if timeout is None else timeout
+                    self.client.hset(self.physical_queue_cache_key.format(queue=queue), queue_name, value)
 
         return result
 
@@ -446,7 +445,7 @@ class Channel(RedisChannel):
     def should_listen(self, queue, physical_queue_name):
         physical_queue = self.get_physical_queues([queue])[queue]
         expiry = physical_queue.queue_expiry(physical_queue_name)
-        if expiry < time():
+        if expiry and expiry < time():
             del self.physical_queue[queue].queues[physical_queue_name]
             self.client.hdel(self.physical_queue_cache_key.format(queue=queue), physical_queue_name)
             return False

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from time import time, sleep
 from queue import Empty
 from collections import defaultdict
+from typing import Set, Dict
 
 from kombu.log import get_logger
 from kombu.utils.encoding import bytes_to_str
@@ -244,6 +245,7 @@ class ClusterPoller(MultiChannelPoller):
     def _get_conns_for_channel(self, channel):
         result = []
         conns = [conn for _, _, conn, _ in self._chan_to_sock]
+
         for key in channel.active_queues:
             try:
                 conn = next(x for x in conns if x.key == key)
@@ -302,6 +304,14 @@ class RedisClusterConnection():
             del cls.connections[key]
 
 
+class RedisNodeConfiguration():
+    def __init__(self, name: str, slots: Set[int]):
+        self.name = name
+        self.slots = slots
+
+    def keyslot_in_node(self, keyslot: int) -> bool:
+        return keyslot in self.slots
+
 class Channel(RedisChannel):
 
     QoS = QoS
@@ -319,7 +329,8 @@ class Channel(RedisChannel):
         'namespace',
         'keyprefix_queue',
         'keyprefix_fanout',
-        'brpop_timeout'
+        'brpop_timeout',
+        'queue_names_per_slot'
     )
 
     def __init__(self, conn, *args, **kwargs):
@@ -342,6 +353,39 @@ class Channel(RedisChannel):
             if P:
                 M, EX, RK = loads(bytes_to_str(P))  # json is unicode
                 self._do_restore_message(M, EX, RK, client, leftmost)
+
+    def get_redis_configuration(self) -> Dict[str, RedisNodeConfiguration]:
+        nodes: Dict[str, RedisNodeConfiguration] = {}
+
+        for slot, node in self.client.nodes_manager.slots_cache.items():
+            found = nodes.get(node[0].name)
+            if found is None:
+                nodes[node[0].name] = RedisNodeConfiguration(name=node[0].name, slots={int(slot)})
+            else:
+                found.slots.add(int(slot))
+        return nodes
+
+    def get_physical_queues(self):
+        redis_configuration = self.get_redis_configuration()
+
+        queue_names_per_slot = self.connection.client.transport_options.get('queue_names_per_slot', None)
+        if not queue_names_per_slot:
+            result = {}
+            for queue in self.active_queues:
+                result[queue] = [queue]
+            return result
+
+        result = {}
+        for queue in self.active_queues:
+            result[queue] = []
+            if queue in queue_names_per_slot:
+                for node in redis_configuration.values():
+                    first_slot = next(iter(node.slots))
+
+                    result[queue].append(queue_names_per_slot[queue][first_slot])
+
+        return result
+
 
     @contextmanager
     def conn_or_acquire(self, client=None):

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -145,7 +145,6 @@ class RedisNodeConnection():
         self.in_poll = False
         self.queue = queue
         self.key = key
-        self.timeout = None
 
 class ClusterPoller(MultiChannelPoller):
     def __init__(self):
@@ -225,8 +224,7 @@ class ClusterPoller(MultiChannelPoller):
                 except Exception as e:
                     logger.error('Error while registering BRPOP', extra={"e": e, "key": conn.key})
 
-        timeout = channel.connection.client.transport_options.get('brpop_timeout', 1)
-        channel._brpop_start(timeout)
+        channel._brpop_start()
 
     def on_poll_init(self, poller):
         self.poller = poller
@@ -319,6 +317,10 @@ class RedisNodeConfiguration():
         return keyslot in self.slots
 
 
+# We create physical queue as a list on each redis cluster node to ensure even distribution.
+# On scale-in/out, we should listen to old queue names for a while to ensure no message is lost.
+# To do this, we compute new physical queue names and set expiry for old queue names on redis slot change event.
+# Also, we store queue names on redis to ensure we don't lose old queue names on worker start.
 class PhysicalQueue():
 
     def __init__(self, queues: Dict[str, Optional[int]]):
@@ -342,6 +344,8 @@ class Channel(RedisChannel):
     unacked_key = '_kombu.unacked.{{{queue}}}'
     unacked_index_key = '_kombu.unacked_index.{{{queue}}}'
     unacked_mutex_key = '_kombu.unacked_mutex.{{{queue}}}'
+    physical_queue_cache_key = '_kombu.physical_queue.{{{queue}}}'
+    physical_queue_timeout = 600000 # 10 minutes
 
     min_priority = 0
     max_priority = 0
@@ -393,11 +397,32 @@ class Channel(RedisChannel):
 
         remaining_queues = [x for x in queues if x not in result]
         if remaining_queues:
-            queue_names = self.compute_physical_queue_names(remaining_queues)
+            new_physical_queues = self.compute_physical_queue_names(remaining_queues)
             for queue in remaining_queues:
-                configuration = PhysicalQueue({x: None for x in queue_names[queue]})
-                result[queue] = configuration
-                self.physical_queues[queue] = configuration
+                # Load queue names from redis to ensure listening physical queues before last redis slot configuration change.
+                cached_physical_queues = self.client.hgetall(self.physical_queue_cache_key.format(queue=queue))
+
+                # Merge cached and computed queue
+                # if newly computed queue is not in cached_queue_names and has no expire, we should set its expiry
+                merged_physical_queues = {}
+
+                for queue_name in new_physical_queues[queue]:
+                    merged_physical_queues[queue_name] = None
+                    if queue_name not in cached_physical_queues:
+                        merged_physical_queues[queue_name] = time() + self.physical_queue_timeout
+                for queue_name, timeout in cached_physical_queues.items():
+                    queue_name = queue_name.decode('utf-8')
+                    if queue_name not in merged_physical_queues:
+                        merged_physical_queues[queue_name] = timeout
+
+                physical_queue = PhysicalQueue(merged_physical_queues)
+
+                result[queue] = physical_queue
+                self.physical_queues[queue] = physical_queue
+
+                # And update cache..
+                for queue_name, timeout in merged_physical_queues.items():
+                    self.client.hset(self.physical_queue_cache_key.format(queue=queue), queue_name, timeout)
 
         return result
 
@@ -455,21 +480,18 @@ class Channel(RedisChannel):
 
         RedisClusterConnection.close(self.client)
 
-    def _brpop_start(self, timeout):
+    def _brpop_start(self):
         queues = self._queue_cycle.consume(len(self.active_queues))
         if not queues:
             return
 
-        timeout = timeout or 0
-
         physical_queues = self.get_physical_queues(queues)
 
-        for physical_queue in physical_queues.values():
+        for queue, physical_queue in physical_queues.items():
             for physical_queue_name in physical_queue.alive_queues():
                 for _, _, conn, _ in self.connection.cycle._chan_to_sock:
                     if conn.key == physical_queue_name and conn.in_poll == False:
                         conn.in_poll = True
-                        conn.timeout = timeout
                         if conn.key in self.ask_errors:
                             del self.ask_errors[conn.key]
                             try:
@@ -478,15 +500,26 @@ class Channel(RedisChannel):
                                 logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
                                 continue
                         try:
-                            queue_timeout = timeout
-                            if physical_queue.queue_expiry(physical_queue_name):
-                                queue_timeout = min(physical_queue.queue_expiry(physical_queue_name) - time(), timeout)
-                            conn.client.connection.send_command('BRPOP', physical_queue_name, queue_timeout)
+                            brpop_timeout = self.get_brpop_timeout(queue, physical_queue_name)
+                            conn.client.connection.send_command('BRPOP', physical_queue_name, brpop_timeout)
                         except:
                             logger.exception('Error while sending BRPOP', extra={"key": conn.key})
                             self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
                         break
 
+    def get_brpop_timeout(self, queue, physical_queue_name):
+        timeout = self.connection.client.transport_options.get('brpop_timeout', 1)
+
+        physical_queue = self.get_physical_queues([queue])[queue]
+
+        expiry = physical_queue.queue_expiry(physical_queue_name)
+        if expiry:
+            if not timeout:
+                return expiry - time()
+            else:
+                return min(expiry - time(), timeout)
+
+        return 0
 
     def _brpop_read(self, **options):
         conn = options.pop('conn')
@@ -497,7 +530,8 @@ class Channel(RedisChannel):
             # We should not throw error on this method to make kombu to continue operation
             raise Empty()
 
-        conn.client.connection.send_command('BRPOP', conn.key, conn.timeout)  # schedule next BRPOP
+        brpop_timeout = self.get_brpop_timeout(conn.queue, conn.key)
+        conn.client.connection.send_command('BRPOP', conn.key, brpop_timeout)  # schedule next BRPOP
 
         if resp:
             self.deliver_response(conn.queue, resp)

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -3,6 +3,7 @@ from time import time, sleep
 from queue import Empty
 from collections import defaultdict
 from typing import Set, Dict
+import random
 
 from kombu.log import get_logger
 from kombu.utils.encoding import bytes_to_str
@@ -139,9 +140,10 @@ class QoS(RedisQoS):
 
 
 class RedisNodeConnection():
-    def __init__(self, key):
+    def __init__(self, queue, key):
         self.client = None
         self.in_poll = False
+        self.queue = queue
         self.key = key
         self.timeout = None
 
@@ -185,6 +187,7 @@ class ClusterPoller(MultiChannelPoller):
         self._chan_to_sock[ident] = sock
         self._sock_to_fd[sock] = sock.fileno()
         self.poller.register(sock, self.eventflags)
+        logger.debug(f'registering to queue {conn.key}')
 
     def _unregister(self, channel, client, conn, cmd):
         sock = self._chan_to_sock[(channel, client, conn, cmd)]
@@ -246,13 +249,16 @@ class ClusterPoller(MultiChannelPoller):
         result = []
         conns = [conn for _, _, conn, _ in self._chan_to_sock]
 
-        for key in channel.active_queues:
-            try:
-                conn = next(x for x in conns if x.key == key)
-                conns.remove(conn)
-            except StopIteration:
-                conn = RedisNodeConnection(key)
-            result.append(conn)
+        queues = channel.get_physical_queues(channel.active_queues)
+
+        for queue_name, queue in queues.items():
+            for key in queue:
+                try:
+                    conn = next(x for x in conns if x.queue == queue_name and x.key == key)
+                    conns.remove(conn)
+                except StopIteration:
+                    conn = RedisNodeConnection(queue_name, key)
+                result.append(conn)
 
         return result
 
@@ -365,18 +371,18 @@ class Channel(RedisChannel):
                 found.slots.add(int(slot))
         return nodes
 
-    def get_physical_queues(self):
+    def get_physical_queues(self, queues):
         redis_configuration = self.get_redis_configuration()
 
         queue_names_per_slot = self.connection.client.transport_options.get('queue_names_per_slot', None)
         if not queue_names_per_slot:
             result = {}
-            for queue in self.active_queues:
+            for queue in queues:
                 result[queue] = [queue]
             return result
 
         result = {}
-        for queue in self.active_queues:
+        for queue in queues:
             result[queue] = []
             if queue in queue_names_per_slot:
                 for node in redis_configuration.values():
@@ -385,6 +391,15 @@ class Channel(RedisChannel):
                     result[queue].append(queue_names_per_slot[queue][first_slot])
 
         return result
+
+    def _q_for_pri(self, queue, pri):
+        queues = self.get_physical_queues([queue])
+        queue = random.choice(queues[queue])
+
+        pri = self.priority(pri)
+        if pri:
+            return "{}{}{}".format(queue, self.sep, pri)
+        return queue
 
 
     @contextmanager
@@ -415,25 +430,30 @@ class Channel(RedisChannel):
         if not queues:
             return
 
-        for key in queues:
-            for _, _, conn, _ in self.connection.cycle._chan_to_sock:
-                if conn.key == key and conn.in_poll == False:
-                    conn.in_poll = True
-                    conn.timeout = timeout
-                    if conn.key in self.ask_errors:
-                        del self.ask_errors[conn.key]
-                        try:
-                            conn.client.execute_command('ASKING')
-                        except Exception as e:
-                            logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
-                            continue
+        timeout = timeout or 0
 
-                    try:
-                        conn.client.connection.send_command('BRPOP', key, timeout)
-                    except:
-                        logger.exception('Error while sending BRPOP', extra={"key": conn.key})
-                        self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
-                    break
+        physical_queues = self.get_physical_queues(queues)
+
+        for queue in physical_queues.values():
+            for key in queue:
+                for _, _, conn, _ in self.connection.cycle._chan_to_sock:
+                    if conn.key == key and conn.in_poll == False:
+                        conn.in_poll = True
+                        conn.timeout = timeout
+                        if conn.key in self.ask_errors:
+                            del self.ask_errors[conn.key]
+                            try:
+                                conn.client.execute_command('ASKING')
+                            except Exception as e:
+                                logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
+                                continue
+                        try:
+                            conn.client.connection.send_command('BRPOP', key, timeout)
+                        except:
+                            logger.exception('Error while sending BRPOP', extra={"key": conn.key})
+                            self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
+                        break
+
 
     def _brpop_read(self, **options):
         conn = options.pop('conn')
@@ -447,14 +467,14 @@ class Channel(RedisChannel):
         conn.client.connection.send_command('BRPOP', conn.key, conn.timeout)  # schedule next BRPOP
 
         if resp:
-            self.deliver_response(resp)
+            self.deliver_response(conn.queue, resp)
             return True
 
     def _poll_error(self, cmd, conn, **options):
         try:
             resp = self.parse_response(conn, 'BRPOP', **options)
             if resp:
-                self.deliver_response(resp)
+                self.deliver_response(conn.queue, resp)
         except Exception:
             # We should not throw error on this method to make kombu to continue operation
             # Error is logged at `parse_response`
@@ -462,9 +482,9 @@ class Channel(RedisChannel):
 
         self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
 
-    def deliver_response(self, resp):
+    def deliver_response(self, queue, resp):
         dest, item = resp
-        dest = bytes_to_str(dest).rsplit(self.sep, 1)[0]
+        dest = bytes_to_str(queue).rsplit(self.sep, 1)[0]
         self._queue_cycle.rotate(dest)
         self.connection._deliver(loads(bytes_to_str(item)), dest)
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -140,11 +140,11 @@ class QoS(RedisQoS):
 
 
 class RedisNodeConnection():
-    def __init__(self, queue, key):
+    def __init__(self, queue, physical_queue):
         self.client = None
         self.in_poll = False
         self.queue = queue
-        self.key = key
+        self.physical_queue = physical_queue
 
 class ClusterPoller(MultiChannelPoller):
     def __init__(self):
@@ -162,17 +162,17 @@ class ClusterPoller(MultiChannelPoller):
             backoff = [0, 0.1, 0.2, 0.4]
             while True:
                 if tries > 3:
-                    raise ValueError('Cannot find node for key: {}'.format(conn.key))
+                    raise ValueError('Cannot find node for key: {}'.format(conn.physical_queue))
                 try:
-                    if conn.key in channel.ask_errors:
-                        ask_error = channel.ask_errors[conn.key]
+                    if conn.physical_queue in channel.ask_errors:
+                        ask_error = channel.ask_errors[conn.physical_queue]
                         node = channel.client.get_node(ask_error.host, ask_error.port)
                     else:
-                        node = channel.client.get_node_from_key(conn.key)
+                        node = channel.client.get_node_from_key(conn.physical_queue)
                     if node:
                         break
                 except Exception as e:
-                    logger.error('Error while getting node from key', extra={"e": e, "key": conn.key})
+                    logger.error('Error while getting node from key', extra={"e": e, "key": conn.physical_queue})
 
                 sleep(backoff[tries])
                 channel.client.nodes_manager.initialize()
@@ -186,7 +186,7 @@ class ClusterPoller(MultiChannelPoller):
         self._chan_to_sock[ident] = sock
         self._sock_to_fd[sock] = sock.fileno()
         self.poller.register(sock, self.eventflags)
-        logger.debug(f'registering to queue {conn.key}')
+        logger.debug(f'registering to queue {conn.physical_queue}')
 
     def _unregister(self, channel, client, conn, cmd):
         sock = self._chan_to_sock[(channel, client, conn, cmd)]
@@ -222,7 +222,7 @@ class ClusterPoller(MultiChannelPoller):
                 try:
                     self._register(*ident)
                 except Exception as e:
-                    logger.error('Error while registering BRPOP', extra={"e": e, "key": conn.key})
+                    logger.error('Error while registering BRPOP', extra={"e": e, "key": conn.physical_queue})
 
         channel._brpop_start()
 
@@ -252,7 +252,7 @@ class ClusterPoller(MultiChannelPoller):
         for queue_name, physical_queue in physical_queues.items():
             for physical_queue_name in physical_queue.alive_queues():
                 try:
-                    conn = next(x for x in conns if x.queue == queue_name and x.key == physical_queue_name)
+                    conn = next(x for x in conns if x.queue == queue_name and x.physical_queue == physical_queue_name)
                     conns.remove(conn)
                 except StopIteration:
                     conn = RedisNodeConnection(queue_name, physical_queue_name)
@@ -516,20 +516,20 @@ class Channel(RedisChannel):
         for queue, physical_queue in physical_queues.items():
             for physical_queue_name in physical_queue.alive_queues():
                 for _, _, conn, _ in self.connection.cycle._chan_to_sock:
-                    if conn.key == physical_queue_name and conn.in_poll == False:
+                    if conn.physical_queue == physical_queue_name and conn.in_poll == False:
                         conn.in_poll = True
-                        if conn.key in self.ask_errors:
-                            del self.ask_errors[conn.key]
+                        if conn.physical_queue in self.ask_errors:
+                            del self.ask_errors[conn.physical_queue]
                             try:
                                 conn.client.execute_command('ASKING')
                             except Exception as e:
-                                logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
+                                logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.physical_queue})
                                 continue
                         try:
                             brpop_timeout = self.get_brpop_timeout(queue, physical_queue_name)
                             conn.client.connection.send_command('BRPOP', physical_queue_name, brpop_timeout)
                         except:
-                            logger.exception('Error while sending BRPOP', extra={"key": conn.key})
+                            logger.exception('Error while sending BRPOP', extra={"key": conn.physical_queue})
                             self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
                         break
 
@@ -542,9 +542,9 @@ class Channel(RedisChannel):
             # We should not throw error on this method to make kombu to continue operation
             raise Empty()
 
-        brpop_timeout = self.get_brpop_timeout(conn.queue, conn.key)
-        if self.should_listen(conn.queue, conn.key):
-            conn.client.connection.send_command('BRPOP', conn.key, brpop_timeout)  # schedule next BRPOP
+        brpop_timeout = self.get_brpop_timeout(conn.queue, conn.physical_queue)
+        if self.should_listen(conn.queue, conn.physical_queue):
+            conn.client.connection.send_command('BRPOP', conn.physical_queue, brpop_timeout)  # schedule next BRPOP
         else:
             self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
 
@@ -574,15 +574,15 @@ class Channel(RedisChannel):
         try:
             return conn.client.parse_response(conn.client.connection, cmd, **options)
         except Exception as e:
-            logger.error('Error while reading from Redis', extra={"e": e, "key": conn.key})
+            logger.error('Error while reading from Redis', extra={"e": e, "key": conn.physical_queue})
 
             # Mostly copied from https://github.com/sendbird/redis-py/blob/master/redis/cluster.py#L1173
             if isinstance(e, ConnectionError) or isinstance(e, TimeoutError):
                 try:
-                    node = channel.client.get_node_from_key(conn.key)
+                    node = channel.client.get_node_from_key(conn.physical_queue)
                     self.client.nodes_manager.startup_nodes.pop(node.name, None)
                 except Exception as e:
-                    logger.error('Error while removing node', extra={"e": e, "key": conn.key})
+                    logger.error('Error while removing node', extra={"e": e, "key": conn.physical_queue})
                 self.client.nodes_manager.initialize()
                 self.redis_configuration_changed()
             elif isinstance(e, MovedError):
@@ -611,7 +611,7 @@ class Channel(RedisChannel):
             raise
 
     def add_ask_error(self, e, conn):
-        self.ask_errors[conn.key] = e
+        self.ask_errors[conn.physical_queue] = e
 
 
 class Transport(RedisTransport):

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -331,6 +331,9 @@ class PhysicalQueue():
 
         return [x for x in self.queues if self.queues[x] is None or self.queues[x] > now]
 
+    def current_queues(self) -> List[str]:
+        return [x for x in self.queues if self.queues[x] is None]
+
     def queue_expiry(self, queue) -> Optional[int]:
         return self.queues[queue]
 
@@ -497,7 +500,7 @@ class Channel(RedisChannel):
 
     def _q_for_pri(self, queue, pri):
         queues = self.get_physical_queues([queue])
-        queue = random.choice(queues[queue].alive_queues())
+        queue = random.choice(queues[queue].current_queues())
 
         pri = self.priority(pri)
         if pri:

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from time import time, sleep
 from queue import Empty
 from collections import defaultdict
-from typing import Set, Dict
+from typing import Set, Dict, Optional, List
 import random
 
 from kombu.log import get_logger
@@ -249,15 +249,15 @@ class ClusterPoller(MultiChannelPoller):
         result = []
         conns = [conn for _, _, conn, _ in self._chan_to_sock]
 
-        queues = channel.get_physical_queues(channel.active_queues)
+        physical_queues = channel.get_physical_queues(channel.active_queues)
 
-        for queue_name, queue in queues.items():
-            for key in queue:
+        for queue_name, physical_queue in physical_queues.items():
+            for physical_queue_name in physical_queue.alive_queues():
                 try:
-                    conn = next(x for x in conns if x.queue == queue_name and x.key == key)
+                    conn = next(x for x in conns if x.queue == queue_name and x.key == physical_queue_name)
                     conns.remove(conn)
                 except StopIteration:
-                    conn = RedisNodeConnection(queue_name, key)
+                    conn = RedisNodeConnection(queue_name, physical_queue_name)
                 result.append(conn)
 
         return result
@@ -318,6 +318,22 @@ class RedisNodeConfiguration():
     def keyslot_in_node(self, keyslot: int) -> bool:
         return keyslot in self.slots
 
+
+class PhysicalQueue():
+
+    def __init__(self, queues: Dict[str, Optional[int]]):
+        self.queues = queues
+
+    def alive_queues(self) -> List[str]:
+        now = time()
+
+        return [x for x in self.queues if self.queues[x] is None or self.queues[x] > now]
+
+    def queue_expiry(self, queue) -> Optional[int]:
+        return self.queues[queue]
+
+
+
 class Channel(RedisChannel):
 
     QoS = QoS
@@ -343,6 +359,7 @@ class Channel(RedisChannel):
         super().__init__(conn, *args, **kwargs)
 
         self.ask_errors = {}
+        self.physical_queues = {}
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
@@ -372,6 +389,19 @@ class Channel(RedisChannel):
         return nodes
 
     def get_physical_queues(self, queues):
+        result = {k: v for k, v in self.physical_queues.items() if k in queues}
+
+        remaining_queues = [x for x in queues if x not in result]
+        if remaining_queues:
+            queue_names = self.compute_physical_queue_names(remaining_queues)
+            for queue in remaining_queues:
+                configuration = PhysicalQueue({x: None for x in queue_names[queue]})
+                result[queue] = configuration
+                self.physical_queues[queue] = configuration
+
+        return result
+
+    def compute_physical_queue_names(self, queues):
         redis_configuration = self.get_redis_configuration()
 
         queue_names_per_slot = self.connection.client.transport_options.get('queue_names_per_slot', None)
@@ -394,7 +424,7 @@ class Channel(RedisChannel):
 
     def _q_for_pri(self, queue, pri):
         queues = self.get_physical_queues([queue])
-        queue = random.choice(queues[queue])
+        queue = random.choice(queues[queue].alive_queues())
 
         pri = self.priority(pri)
         if pri:
@@ -434,10 +464,10 @@ class Channel(RedisChannel):
 
         physical_queues = self.get_physical_queues(queues)
 
-        for queue in physical_queues.values():
-            for key in queue:
+        for physical_queue in physical_queues.values():
+            for physical_queue_name in physical_queue.alive_queues():
                 for _, _, conn, _ in self.connection.cycle._chan_to_sock:
-                    if conn.key == key and conn.in_poll == False:
+                    if conn.key == physical_queue_name and conn.in_poll == False:
                         conn.in_poll = True
                         conn.timeout = timeout
                         if conn.key in self.ask_errors:
@@ -448,7 +478,10 @@ class Channel(RedisChannel):
                                 logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
                                 continue
                         try:
-                            conn.client.connection.send_command('BRPOP', key, timeout)
+                            queue_timeout = timeout
+                            if physical_queue.queue_expiry(physical_queue_name):
+                                queue_timeout = min(physical_queue.queue_expiry(physical_queue_name) - time(), timeout)
+                            conn.client.connection.send_command('BRPOP', physical_queue_name, queue_timeout)
                         except:
                             logger.exception('Error while sending BRPOP', extra={"key": conn.key})
                             self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -316,6 +316,9 @@ class RedisNodeConfiguration():
     def keyslot_in_node(self, keyslot: int) -> bool:
         return keyslot in self.slots
 
+    def __eq__(self, other):
+        return self.name == other.name and self.slots == other.slots
+
 
 # We create physical queue as a list on each redis cluster node to ensure even distribution.
 # On scale-in/out, we should listen to old queue names for a while to ensure no message is lost.
@@ -367,7 +370,8 @@ class Channel(RedisChannel):
 
         self.ask_errors = {}
         self.physical_queues = {}
-        self.physical_queues_updated_at = 0
+        self.redis_configuration_checked_at = 0
+        self.last_redis_configuration = self.get_redis_configuration()
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
@@ -388,13 +392,27 @@ class Channel(RedisChannel):
     def get_redis_configuration(self) -> Dict[str, RedisNodeConfiguration]:
         nodes: Dict[str, RedisNodeConfiguration] = {}
 
-        for slot, node in self.client.nodes_manager.slots_cache.items():
-            found = nodes.get(node[0].name)
-            if found is None:
-                nodes[node[0].name] = RedisNodeConfiguration(name=node[0].name, slots={int(slot)})
-            else:
-                found.slots.add(int(slot))
+        try:
+            cluster_slots = self.client.cluster_slots()
+        except:
+            logger.exception("failed to get redis configuration")
+            return None
+
+        for slot, node in cluster_slots.items():
+            name = f"{node['primary'][0]}:{node['primary'][1]}"
+
+            nodes[name] = RedisNodeConfiguration(name=name, slots={x for x in range(slot[0], slot[1] + 1)})
+
         return nodes
+
+    def update_redis_configuration(self) -> bool:
+        last = self.last_redis_configuration
+        new = self.get_redis_configuration()
+
+        if new is not None and last != new:
+            self.last_redis_configuration = new
+            return True
+        return False
 
     def redis_configuration_changed(self):
         self.physical_queues = {}  # Will be recomputed later
@@ -402,9 +420,11 @@ class Channel(RedisChannel):
     def get_physical_queues(self, queues):
         now = time()
 
-        if now - self.physical_queues_updated_at > 60:
-            self.physical_queues = {}  # update physical queue configuration every minute
-            self.physical_queues_updated_at = now
+        # check redis configuration change every 10 seconds
+        if now - self.redis_configuration_checked_at > 10:
+            if self.update_redis_configuration():
+                self.physical_queues = {}
+            self.redis_configuration_checked_at = now
 
         result = {k: v for k, v in self.physical_queues.items() if k in queues}
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -401,7 +401,10 @@ class Channel(RedisChannel):
         for slot, node in cluster_slots.items():
             name = f"{node['primary'][0]}:{node['primary'][1]}"
 
-            nodes[name] = RedisNodeConfiguration(name=name, slots={x for x in range(slot[0], slot[1] + 1)})
+            if name in nodes:
+                nodes[name].slots.update(range(slot[0], slot[1] + 1))
+            else:
+                nodes[name] = RedisNodeConfiguration(name=name, slots={x for x in range(slot[0], slot[1] + 1)})
 
         return nodes
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -392,6 +392,9 @@ class Channel(RedisChannel):
                 found.slots.add(int(slot))
         return nodes
 
+    def redis_configuration_changed(self):
+        self.physical_queues = {}  # Will be recomputed later
+
     def get_physical_queues(self, queues):
         result = {k: v for k, v in self.physical_queues.items() if k in queues}
 
@@ -569,6 +572,7 @@ class Channel(RedisChannel):
                 except Exception as e:
                     logger.error('Error while removing node', extra={"e": e, "key": conn.key})
                 self.client.nodes_manager.initialize()
+                self.redis_configuration_changed()
             elif isinstance(e, MovedError):
                 self.client.reinitialize_counter += 1
                 if self.client._should_reinitialized():
@@ -576,17 +580,20 @@ class Channel(RedisChannel):
                     self.client.reinitialize_counter = 0
                 else:
                     self.client.nodes_manager.update_moved_exception(e)
+                self.redis_configuration_changed()
             elif isinstance(e, SlotNotCoveredError):
                 self.client.reinitialize_counter += 1
                 if self.client._should_reinitialized():
                     self.client.nodes_manager.initialize()
                     self.client.reinitialize_counter = 0
+                    self.redis_configuration_changed()
             elif isinstance(e, TryAgainError):
                 return  # try again in next BRPOP
             elif isinstance(e, AskError):
                 self.add_ask_error(e, conn)
             elif isinstance(e, ClusterDownError):
                 self.client.nodes_manager.initialize()
+                self.redis_configuration_changed()
 
             self.connection.cycle._unregister(self, self.client, conn, cmd)
             raise

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -415,7 +415,8 @@ class Channel(RedisChannel):
         return False
 
     def redis_configuration_changed(self):
-        self.physical_queues = {}  # Will be recomputed later
+        self.physical_queues = {}
+        self.update_redis_configuration()
 
     def get_physical_queues(self, queues):
         now = time()

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -499,8 +499,8 @@ class Channel(RedisChannel):
         return result
 
     def _q_for_pri(self, queue, pri):
-        queues = self.get_physical_queues([queue])
-        queue = random.choice(queues[queue].current_queues())
+        physical_queues = self.get_physical_queues([queue])
+        queue = random.choice(physical_queues[queue].current_queues())
 
         pri = self.priority(pri)
         if pri:

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -513,9 +513,9 @@ class Channel(RedisChannel):
             result[queue] = []
             if queue in queue_names_per_slot:
                 for node in redis_configuration.values():
-                    first_slot = next(iter(node.slots))
+                    last_slot = list(node.slots).pop()
 
-                    result[queue].append(queue_names_per_slot[queue][first_slot])
+                    result[queue].append(queue_names_per_slot[queue][last_slot])
             else:
                 logger.warning('no %s in queue_names_per_slot option, defaulting to single queue', queue)
                 result[queue] = [queue]

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -345,7 +345,7 @@ class Channel(RedisChannel):
     unacked_index_key = '_kombu.unacked_index.{{{queue}}}'
     unacked_mutex_key = '_kombu.unacked_mutex.{{{queue}}}'
     physical_queue_cache_key = '_kombu.physical_queue.{{{queue}}}'
-    physical_queue_timeout = 600000 # 10 minutes
+    physical_queue_timeout = 600 # 10 minutes
 
     min_priority = 0
     max_priority = 0
@@ -397,7 +397,7 @@ class Channel(RedisChannel):
         self.physical_queues = {}  # Will be recomputed later
 
     def get_physical_queues(self, queues):
-        if self.physical_queues_updated_at and time() - self.physical_queues_updated_at > 60000:
+        if self.physical_queues_updated_at and time() - self.physical_queues_updated_at > 60:
             self.physical_queues = {}  # update physical queue configuration every minute
             self.physical_queues_updated_at = time()
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -613,6 +613,9 @@ class Channel(RedisChannel):
     def add_ask_error(self, e, conn):
         self.ask_errors[conn.physical_queue] = e
 
+    def _lookup(self, exchange, routing_key, default=None):
+        return [self._q_for_pri(routing_key, 0)]
+
 
 class Transport(RedisTransport):
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -411,6 +411,7 @@ class Channel(RedisChannel):
 
                 for queue_name, timeout in cached_physical_queues.items():
                     queue_name = queue_name.decode('utf-8')
+                    timeout = int(timeout)
                     if queue_name not in merged_physical_queues:
                         if timeout == 0:
                             timeout = int(time() + self.physical_queue_timeout)

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -495,7 +495,7 @@ class Channel(RedisChannel):
         return True
 
     def compute_physical_queue_names(self, queues):
-        redis_configuration = self.get_redis_configuration()
+        redis_configuration = self.last_redis_configuration
 
         queue_names_per_slot = self.connection.client.transport_options.get('queue_names_per_slot', None)
         if not queue_names_per_slot:

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -397,9 +397,11 @@ class Channel(RedisChannel):
         self.physical_queues = {}  # Will be recomputed later
 
     def get_physical_queues(self, queues):
-        if self.physical_queues_updated_at and time() - self.physical_queues_updated_at > 60:
+        now = time()
+
+        if self.physical_queues_updated_at and now - self.physical_queues_updated_at > 60:
             self.physical_queues = {}  # update physical queue configuration every minute
-            self.physical_queues_updated_at = time()
+            self.physical_queues_updated_at = now
 
         result = {k: v for k, v in self.physical_queues.items() if k in queues}
 
@@ -418,13 +420,18 @@ class Channel(RedisChannel):
                 # if cached_queue_names is not in new_physical_queues and has no expire, we should set its expiry
                 merged_physical_queues: Dict[str, Optional[int]] = {x: None for x in new_physical_queues[queue]}
 
-                for queue_name, timeout in cached_physical_queues.items():
+                for queue_name, expiry in cached_physical_queues.items():
                     queue_name = queue_name.decode('utf-8')
-                    timeout = int(timeout)
-                    if queue_name not in merged_physical_queues:
-                        if timeout == 0:
-                            timeout = int(time() + self.physical_queue_timeout)
-                        merged_physical_queues[queue_name] = timeout
+                    expiry = int(expiry)
+                    if expiry < now:
+                        try:
+                            self.client.hdel(self.physical_queue_cache_key.format(queue=queue), queue_name)
+                        except:
+                            logger.exception('Failed to delete cache', extra={'queue': queue, 'queue_name': queue_name})
+                    elif queue_name not in merged_physical_queues:
+                        if expiry == 0:
+                            expiry = int(now + self.physical_queue_timeout)
+                        merged_physical_queues[queue_name] = expiry
 
                 physical_queue = PhysicalQueue(merged_physical_queues)
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -429,6 +429,29 @@ class Channel(RedisChannel):
 
         return result
 
+    def get_brpop_timeout(self, queue, physical_queue_name):
+        timeout = self.connection.client.transport_options.get('brpop_timeout', 1)
+
+        physical_queue = self.get_physical_queues([queue])[queue]
+        expiry = physical_queue.queue_expiry(physical_queue_name)
+
+        if expiry:
+            if not timeout:
+                return expiry - time()
+            else:
+                return min(expiry - time(), timeout)
+
+        return 0
+
+    def should_listen(self, queue, physical_queue_name):
+        physical_queue = self.get_physical_queues([queue])[queue]
+        expiry = physical_queue.queue_expiry(physical_queue_name)
+        if expiry < time():
+            del self.physical_queue[queue].queues[physical_queue_name]
+            self.client.hdel(self.physical_queue_cache_key.format(queue=queue), physical_queue_name)
+            return False
+        return True
+
     def compute_physical_queue_names(self, queues):
         redis_configuration = self.get_redis_configuration()
 
@@ -510,20 +533,6 @@ class Channel(RedisChannel):
                             self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
                         break
 
-    def get_brpop_timeout(self, queue, physical_queue_name):
-        timeout = self.connection.client.transport_options.get('brpop_timeout', 1)
-
-        physical_queue = self.get_physical_queues([queue])[queue]
-
-        expiry = physical_queue.queue_expiry(physical_queue_name)
-        if expiry:
-            if not timeout:
-                return expiry - time()
-            else:
-                return min(expiry - time(), timeout)
-
-        return 0
-
     def _brpop_read(self, **options):
         conn = options.pop('conn')
 
@@ -534,7 +543,10 @@ class Channel(RedisChannel):
             raise Empty()
 
         brpop_timeout = self.get_brpop_timeout(conn.queue, conn.key)
-        conn.client.connection.send_command('BRPOP', conn.key, brpop_timeout)  # schedule next BRPOP
+        if self.should_listen(conn.queue, conn.key):
+            conn.client.connection.send_command('BRPOP', conn.key, brpop_timeout)  # schedule next BRPOP
+        else:
+            self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
 
         if resp:
             self.deliver_response(conn.queue, resp)

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -470,6 +470,9 @@ class Channel(RedisChannel):
                     first_slot = next(iter(node.slots))
 
                     result[queue].append(queue_names_per_slot[queue][first_slot])
+            else:
+                logger.warning('no %s in queue_names_per_slot option, defaulting to single queue', queue)
+                result[queue] = [queue]
 
         return result
 

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -367,7 +367,7 @@ class Channel(RedisChannel):
 
         self.ask_errors = {}
         self.physical_queues = {}
-        self.physical_queues_updated_at = None
+        self.physical_queues_updated_at = 0
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
@@ -402,7 +402,7 @@ class Channel(RedisChannel):
     def get_physical_queues(self, queues):
         now = time()
 
-        if self.physical_queues_updated_at and now - self.physical_queues_updated_at > 60:
+        if now - self.physical_queues_updated_at > 60:
             self.physical_queues = {}  # update physical queue configuration every minute
             self.physical_queues_updated_at = now
 

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -263,6 +263,8 @@ def test_physical_queue_names_cache():
     queues = get_queue_names('queue')
 
     conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'queue': queues}})
+    key = conn.default_channel.physical_queue_cache_key.format(queue='queue')
+    conn.default_channel.client.delete(key)
 
     queue = conn.SimpleQueue('queue')
     queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
@@ -281,3 +283,74 @@ def test_physical_queue_names_cache():
 
     conn.close()
 
+    def patched_get_redis_configuration(self):
+        from kombu.transport.redis_cluster import RedisNodeConfiguration
+
+        return {
+            "node1": RedisNodeConfiguration("node1", set(range(5000, 10999))),
+            "node2": RedisNodeConfiguration("node2", set(range(11000, 16383))),
+            "node3": RedisNodeConfiguration("node3", set(range(0, 4999))),
+        }
+
+    with patch('kombu.transport.redis_cluster.Channel.get_redis_configuration', patched_get_redis_configuration):
+        conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'queue': queues}})
+
+        queue = conn.SimpleQueue('queue')
+        queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+
+        message = queue.get(timeout=1)
+        assert message.payload == {'Hello': 'World'}
+        assert message.content_type == 'application/json'
+        assert message.content_encoding == 'utf-8'
+        assert message.headers == {'k1': 'v1'}
+        message.ack()
+
+        key = conn.default_channel.physical_queue_cache_key.format(queue='queue')
+        new_result = conn.default_channel.client.hgetall(key)
+        for queue, item in new_result.items():
+            if queue in result and queue != b'test:{queue937}':  # 937 is for slot 0
+                assert item != b'0'  # should have some timeout for old queue
+            else:
+                assert item == b'0'
+
+        conn.close()
+
+
+def test_redis_slot_configuration_change():
+    queues = get_queue_names('queue')
+
+    conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'queue': queues}})
+    key = conn.default_channel.physical_queue_cache_key.format(queue='queue')
+    conn.default_channel.client.delete(key)
+
+    queue = conn.SimpleQueue('queue')
+    queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+
+    message = queue.get(timeout=1)
+    assert message.payload == {'Hello': 'World'}
+    assert message.content_type == 'application/json'
+    assert message.content_encoding == 'utf-8'
+    assert message.headers == {'k1': 'v1'}
+    message.ack()
+
+    def patched_get_redis_configuration(self):
+        from kombu.transport.redis_cluster import RedisNodeConfiguration
+
+        return {
+            "node1": RedisNodeConfiguration("node1", set(range(5000, 10999))),
+            "node2": RedisNodeConfiguration("node2", set(range(11000, 16383))),
+            "node3": RedisNodeConfiguration("node3", set(range(0, 4999))),
+        }
+
+    with patch('kombu.transport.redis_cluster.Channel.get_redis_configuration', patched_get_redis_configuration):
+        conn.default_channel.redis_configuration_changed()
+
+        queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+        message = queue.get(timeout=1)
+        assert message.payload == {'Hello': 'World'}
+        assert message.content_type == 'application/json'
+        assert message.content_encoding == 'utf-8'
+        assert message.headers == {'k1': 'v1'}
+        message.ack()
+
+    conn.close()

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -226,7 +226,7 @@ def test_physical_queue_names_precomputed():
 
     conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'test': queues}})
     conn.default_channel._active_queues.append('test')
-    queues = conn.default_channel.get_physical_queues()
+    queues = conn.default_channel.compute_physical_queue_names(['test'])
     assert queues == {'test': ['test:{queue937}', 'test:{queue20909}', 'test:{queue9161}']}
 
     conn.close()
@@ -235,7 +235,7 @@ def test_physical_queue_names_precomputed():
 def test_physical_queue_names():
     conn = kombu.Connection('redis-cluster://localhost:7000')
     conn.default_channel._active_queues.append('test')
-    queues = conn.default_channel.get_physical_queues()
+    queues = conn.default_channel.compute_physical_queue_names(['test'])
     assert queues == {'test': ['test']}
 
     conn.close()

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 import os
-import queue
+from case import patch
 
 import pytest
 import redis
-
-from case import patch
-
 from redis.exceptions import MovedError, AskError
+from redis.crc import key_slot, REDIS_CLUSTER_HASH_SLOTS
 
 import kombu
-from kombu.transport.redis_cluster import Transport
 
 from .common import (BasicFunctionality)
 
@@ -206,3 +203,34 @@ def test_many_queue(connection):
             assert message.content_encoding == 'utf-8'
             assert message.headers == {'k1': 'v1'}
             message.ack()
+
+
+def test_physical_queue_names_precomputed():
+    queues = {}
+    remaining = REDIS_CLUSTER_HASH_SLOTS
+    for i in range(0, 2**32):
+        key = f'test:{{queue{i}}}'
+        keyslot = key_slot(key.encode('utf-8'))
+
+        if keyslot not in queues:
+            queues[keyslot] = key
+            remaining -= 1
+
+        if remaining == 0:
+            break
+
+    conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'test': queues}})
+    conn.default_channel._active_queues.append('test')
+    queues = conn.default_channel.get_physical_queues()
+    assert queues == {'test': ['test:{queue937}', 'test:{queue20909}', 'test:{queue9161}']}
+
+    conn.close()
+
+
+def test_physical_queue_names():
+    conn = kombu.Connection('redis-cluster://localhost:7000')
+    conn.default_channel._active_queues.append('test')
+    queues = conn.default_channel.get_physical_queues()
+    assert queues == {'test': ['test']}
+
+    conn.close()

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -227,7 +227,7 @@ def test_physical_queue_names_precomputed():
     conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'test': queues}})
     conn.default_channel._active_queues.append('test')
     queues = conn.default_channel.compute_physical_queue_names(['test'])
-    assert queues == {'test': ['test:{queue937}', 'test:{queue20909}', 'test:{queue9161}']}
+    assert queues == {'test': ['test:{queue2835}', 'test:{queue17909}', 'test:{queue48526}']}
 
     conn.close()
 
@@ -278,7 +278,7 @@ def test_physical_queue_names_cache():
 
     key = conn.default_channel.physical_queue_cache_key.format(queue='queue')
     result = conn.default_channel.client.hgetall(key)
-    expected = {b'test:{queue937}': b'0', b'test:{queue20909}': b'0', b'test:{queue9161}': b'0'}
+    expected = {b'test:{queue2835}': b'0', b'test:{queue17909}': b'0', b'test:{queue48526}': b'0'}
     assert result == expected
 
     conn.close()

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -205,11 +205,11 @@ def test_many_queue(connection):
             message.ack()
 
 
-def test_physical_queue_names_precomputed():
+def get_queue_names(queue: str):
     queues = {}
     remaining = REDIS_CLUSTER_HASH_SLOTS
     for i in range(0, 2**32):
-        key = f'test:{{queue{i}}}'
+        key = f'test:{{{queue}{i}}}'
         keyslot = key_slot(key.encode('utf-8'))
 
         if keyslot not in queues:
@@ -218,6 +218,11 @@ def test_physical_queue_names_precomputed():
 
         if remaining == 0:
             break
+
+    return queues
+
+def test_physical_queue_names_precomputed():
+    queues = get_queue_names('queue')
 
     conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'test': queues}})
     conn.default_channel._active_queues.append('test')
@@ -232,5 +237,23 @@ def test_physical_queue_names():
     conn.default_channel._active_queues.append('test')
     queues = conn.default_channel.get_physical_queues()
     assert queues == {'test': ['test']}
+
+    conn.close()
+
+
+def test_physical_queue_names_messages():
+    queues = get_queue_names('queue')
+
+    conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'queue': queues}})
+
+    queue = conn.SimpleQueue('queue')
+    queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+
+    message = queue.get(timeout=1)
+    assert message.payload == {'Hello': 'World'}
+    assert message.content_type == 'application/json'
+    assert message.content_encoding == 'utf-8'
+    assert message.headers == {'k1': 'v1'}
+    message.ack()
 
     conn.close()

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -257,3 +257,27 @@ def test_physical_queue_names_messages():
     message.ack()
 
     conn.close()
+
+
+def test_physical_queue_names_cache():
+    queues = get_queue_names('queue')
+
+    conn = kombu.Connection('redis-cluster://localhost:7000', transport_options={'queue_names_per_slot': {'queue': queues}})
+
+    queue = conn.SimpleQueue('queue')
+    queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+
+    message = queue.get(timeout=1)
+    assert message.payload == {'Hello': 'World'}
+    assert message.content_type == 'application/json'
+    assert message.content_encoding == 'utf-8'
+    assert message.headers == {'k1': 'v1'}
+    message.ack()
+
+    key = conn.default_channel.physical_queue_cache_key.format(queue='queue')
+    result = conn.default_channel.client.hgetall(key)
+    expected = {b'test:{queue937}': b'0', b'test:{queue20909}': b'0', b'test:{queue9161}': b'0'}
+    assert result == expected
+
+    conn.close()
+


### PR DESCRIPTION
This PR adds concept of 'physical queue' to evenly distribute queue to multiple redis-cluster nodes.

'physical queue' is determined by precomputed list of queue names for each redis slot(1-16384), given by `queue_name_per_slots` option.

to not to lose messages during scaleout/in event, 'physical queue' names are also saved in redis, and by using saved names, consumers listen to previous queue names for some period of time on redis configuration change.