### PR TITLE
Remove unused info() call

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -322,7 +322,6 @@ class Channel(RedisChannel):
     def __init__(self, conn, *args, **kwargs):
         super().__init__(conn, *args, **kwargs)
 
-        self.client.info()
         self.ask_errors = {}
 
     def _restore(self, message, leftmost=False):


### PR DESCRIPTION
This info() call adds unrequired additional redis connection to default node