### PR TITLE
Catch exception while sending BRPOP

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -384,7 +384,11 @@ class Channel(RedisChannel):
                             logger.warning('Error while sending ASKING', extra={"e": e, "key": conn.key})
                             continue
 
-                    conn.client.connection.send_command('BRPOP', key, timeout)
+                    try:
+                        conn.client.connection.send_command('BRPOP', key, timeout)
+                    except:
+                        logger.exception('Error while sending BRPOP', extra={"key": conn.key})
+                        self.connection.cycle._unregister(self, self.client, conn, cmd)
                     break
 
     def _brpop_read(self, **options):

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -388,7 +388,7 @@ class Channel(RedisChannel):
                         conn.client.connection.send_command('BRPOP', key, timeout)
                     except:
                         logger.exception('Error while sending BRPOP', extra={"key": conn.key})
-                        self.connection.cycle._unregister(self, self.client, conn, cmd)
+                        self.connection.cycle._unregister(self, self.client, conn, 'BRPOP')
                     break
 
     def _brpop_read(self, **options):

--- a/t/integration/test_redis_cluster.py
+++ b/t/integration/test_redis_cluster.py
@@ -74,6 +74,27 @@ def test_connection_reuse(connection):
     assert len(RedisClusterConnection.connections) == 0
 
 
+def test_brpop_send_error(connection):
+    with connection as conn:
+        queue = conn.SimpleQueue('test_connectionerror')
+        queue.put({'Hello': 'World'}, headers={'k1': 'v1'})
+
+        original_send_command = redis.connection.Connection.send_command
+        def send_command(*args, **kwargs):
+            if args[1] == 'BRPOP':
+                raise redis.exceptions.ConnectionError()
+            else:
+                return original_send_command(*args)
+
+        with patch('redis.connection.Connection.send_command', send_command):
+            try:
+                _ = queue.get(timeout=1)
+            except queue.Empty:
+                pass
+            except:
+                raise
+
+
 def test_ssl_connection():
     def patched_init(self, **kwargs):
         assert kwargs['password'] == 'test_password'


### PR DESCRIPTION
If we don't catch error here, kombu will make an infinite loop as there's outer `While 1` loop at  https://github.com/sendbird/kombu/blob/master/kombu/transport/virtual/base.py#L964