### PR TITLE
Remove invalid fd from poller

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -265,6 +265,7 @@ class ClusterPoller(MultiChannelPoller):
         try:
             chan, conn, cmd = self._fd_to_chan[fileno]
         except KeyError:
+            self.poller.unregister(fileno)
             return
 
         if chan.qos.can_consume():


### PR DESCRIPTION
Remove invalid fd from poller, as it will cause poll() to return immediately.