### PR TITLE
[CPLAT-8735] fix busy loop

### DIFF
--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -348,11 +348,16 @@ class Channel(RedisChannel):
         'brpop_timeout'
     )
 
+    # Backoff settings for _brpop_read errors to prevent tight loop on broken connections
+    BRPOP_ERROR_BACKOFF_MIN = 0.1  # 100ms initial backoff
+    BRPOP_ERROR_BACKOFF_MAX = 5.0  # 5s max backoff
+
     def __init__(self, conn, *args, **kwargs):
         super().__init__(conn, *args, **kwargs)
 
         self.ask_errors = {}
         self.consumer_created = False
+        self._brpop_error_backoff = self.BRPOP_ERROR_BACKOFF_MIN
 
     def _restore(self, message, leftmost=False):
         if not self.ack_emulation:
@@ -449,8 +454,23 @@ class Channel(RedisChannel):
         try:
             resp = self.parse_response(conn, 'BRPOP', **options)
         except:
-            # We should not throw error on this method to make kombu to continue operation
+            # Apply exponential backoff to prevent tight loop on broken connections.
+            # Without this, a broken socket (always "readable") causes 100% CPU spin.
+            logger.warning(
+                'BRPOP read error, backing off %.1fs before retry',
+                self._brpop_error_backoff,
+                extra={"key": conn.key},
+            )
+            sleep(self._brpop_error_backoff)
+            # Exponential backoff: double each time, up to max
+            self._brpop_error_backoff = min(
+                self._brpop_error_backoff * 2,
+                self.BRPOP_ERROR_BACKOFF_MAX,
+            )
             raise Empty()
+
+        # Success: reset backoff
+        self._brpop_error_backoff = self.BRPOP_ERROR_BACKOFF_MIN
 
         conn.redis_connection.connection.send_command('BRPOP', conn.key, conn.timeout)  # schedule next BRPOP
 

--- a/t/unit/transport/test_redis_cluster.py
+++ b/t/unit/transport/test_redis_cluster.py
@@ -1,0 +1,74 @@
+"""Tests for redis_cluster transport."""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+
+class TestChannelBrpopBackoff:
+    """Tests for _brpop_read exponential backoff."""
+
+    @pytest.fixture
+    def channel(self):
+        """Create a minimal Channel mock for testing backoff logic."""
+        from kombu.transport.redis_cluster import Channel
+
+        # Create a mock channel with just the backoff attributes
+        channel = mock.MagicMock(spec=Channel)
+        channel.BRPOP_ERROR_BACKOFF_MIN = 0.1
+        channel.BRPOP_ERROR_BACKOFF_MAX = 5.0
+        channel._brpop_error_backoff = channel.BRPOP_ERROR_BACKOFF_MIN
+        return channel
+
+    def test_backoff_constants(self):
+        """Test that backoff constants are set correctly."""
+        from kombu.transport.redis_cluster import Channel
+
+        assert Channel.BRPOP_ERROR_BACKOFF_MIN == 0.1
+        assert Channel.BRPOP_ERROR_BACKOFF_MAX == 5.0
+
+    def test_backoff_increases_exponentially(self, channel):
+        """Test that backoff doubles on each consecutive error."""
+        backoffs = []
+        current = channel.BRPOP_ERROR_BACKOFF_MIN
+
+        for _ in range(6):
+            backoffs.append(current)
+            current = min(current * 2, channel.BRPOP_ERROR_BACKOFF_MAX)
+
+        expected = [0.1, 0.2, 0.4, 0.8, 1.6, 3.2]
+        assert backoffs == expected
+
+    def test_backoff_caps_at_max(self, channel):
+        """Test that backoff doesn't exceed max."""
+        current = channel.BRPOP_ERROR_BACKOFF_MIN
+
+        for _ in range(10):
+            current = min(current * 2, channel.BRPOP_ERROR_BACKOFF_MAX)
+
+        assert current == channel.BRPOP_ERROR_BACKOFF_MAX
+
+    def test_backoff_resets_on_success(self, channel):
+        """Test that backoff resets to min after success."""
+        # Simulate errors increasing backoff
+        channel._brpop_error_backoff = 3.2
+
+        # Simulate success resetting backoff
+        channel._brpop_error_backoff = channel.BRPOP_ERROR_BACKOFF_MIN
+
+        assert channel._brpop_error_backoff == 0.1
+
+    def test_cpu_impact_with_backoff(self, channel):
+        """Test that backoff significantly reduces CPU impact."""
+        total_sleep = 0.0
+        current = channel.BRPOP_ERROR_BACKOFF_MIN
+
+        # Simulate 20 consecutive errors
+        for _ in range(20):
+            total_sleep += current
+            current = min(current * 2, channel.BRPOP_ERROR_BACKOFF_MAX)
+
+        # Without backoff: ~0s (tight loop)
+        # With backoff: >70s total sleep
+        assert total_sleep > 70, f"Expected >70s, got {total_sleep}"


### PR DESCRIPTION
When broker connection breaks, the socket FD becomes stuck in a
"readable" state. poll() returns immediately, _brpop_read() fails,
raises Empty(), and the cycle repeats with no delay - causing 100%
CPU usage in a tight loop.

Add exponential backoff (0.1s to 5s) on _brpop_read errors:
- Log warning with current backoff duration
- Sleep before raising Empty()
- Double backoff on each consecutive error (up to 5s max)
- Reset backoff to 0.1s on successful read

This prevents CPU spin while still allowing quick recovery when
the connection is restored.
